### PR TITLE
initial version of group access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov-badge]][codecov]
 ![go-version-badge]
 
-This is a backend plugin to be used with Vault. This plugin generates [Gitlab Project Access Tokens][pat]
+This is a backend plugin to be used with Vault. This plugin generates [Project Access Tokens][pat] and [Group Access Tokens][gat]
 
 - [Requirements](#requirements)
 - [Getting Started](#getting-started)
@@ -17,12 +17,12 @@ This is a backend plugin to be used with Vault. This plugin generates [Gitlab Pr
 
 ## Requirements
 
-- Gitlab instance with **13.10** or later for API compatibility
+- Gitlab instance with **13.10** or later for API compatibility for [Project Access Tokens][pat] and **14.7** or later for [Group Access Tokens][gat]
 - You need **14.1** or later to have access level
 - Self-managed instances on Free and above. Or, GitLab SaaS Premium and above
-- a token of a user with maintainer or higher permission in a project
+- a token of a user with maintainer or higher permission in a project or group
 
-- Lifting API rate limit for the user whose token will be used in this plugin to generate/revoke project access tokens. Admin of self-hosted can check [this doc][lift rate limit] to allow specific users to bypass authenticated request rate limiting. For SaaS Gitlab, I have not confirmed how to lift API limit yet.
+- Lifting API rate limit for the user whose token will be used in this plugin to generate/revoke project/group access tokens. Admin of self-hosted can check [this doc][lift rate limit] to allow specific users to bypass authenticated request rate limiting. For SaaS Gitlab, I have not confirmed how to lift API limit yet.
 
 ## Getting Started
 
@@ -143,6 +143,7 @@ Please refer [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF
 [Apache Software License version 2.0](LICENSE)
 
 [pat]: https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html
+[gat]: https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html
 [lift rate limit]: https://docs.gitlab.com/ee/user/admin_area/settings/user_and_ip_rate_limits.html#allow-specific-users-to-bypass-authenticated-request-rate-limiting
 [vault-plugin-secrets-artifactory]: https://github.com/splunk/vault-plugin-secrets-artifactory
 [vault plugin]:https://www.vaultproject.io/docs/internals/plugins.html

--- a/docs/backlogs.md
+++ b/docs/backlogs.md
@@ -31,6 +31,6 @@ For comprehensive CI,
 
 ## Acceptance Testing
 
-Running test against real servers doesn't seem good idea. Create an isolated environment by spinning up vault and gitlab in docker in CI. Then, run full suite of testing there. *Self-hosted GitLab has project access token available from free version*
+Running test against real servers doesn't seem good idea. Create an isolated environment by spinning up vault and gitlab in docker in CI. Then, run full suite of testing there. *Self-hosted GitLab has project/group access token available from free version*
 
 [granular control on token expiry]: https://gitlab.com/gitlab-org/gitlab/-/issues/335535

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -9,11 +9,11 @@ This plugin supports two ways to generate a token in `/token` path
 1. At root of `/token` path, a user requests a token by passing parameters.
 2. (WIP): A user predefines roles with parameters. Then, a user can request a role's token at `/token/:<role-name>`
 
-Parameters are same from Gitlab's [Project Access Token API]
+Parameters are same from Gitlab's [Project Access Token API] and [Group Access Token API], make sure to pass `type` field with project/group
 
 path `/token`
 
-- Create/Update: generate a project access token with given parameters
+- Create/Update: generate a project/group access token with given parameters
 
 path `/roles/:<role_name>`
 
@@ -24,7 +24,7 @@ path `/roles/:<role_name>`
 
 path `/token/:<role_name>`
 
-- Create/Update: generate a project access token with stored parameters for the role
+- Create/Update: generate a project/group access token with stored parameters for the role
 
 ## Things to Note
 
@@ -35,8 +35,9 @@ There are 2 kinds of access control in this plugins.
 1. permissions attaches to the configured token
 1. Vault resource access control - path access and capabilities
 
-Root `/token` path can be used to request a project access token for any projects and any scopes as long as the configured token to generate access tokens have necessary permissions in these projects. 2nd kind of access token can't limit parameters to pass.
+Root `/token` path can be used to request a project/group access token for any projects/groups and any scopes as long as the configured token to generate access tokens have necessary permissions in these projects/groups. 2nd kind of access token can't limit parameters to pass.
 
-With that being said, it's better to use **roles**, which predefines a project and scopes; then, requesting a project access token for a role. You can further limit access to path via 2nd kind of access control imposed by Vault
+With that being said, it's better to use **roles**, which predefines a project/groups and scopes; then, requesting a project/group access token for a role. You can further limit access to path via 2nd kind of access control imposed by Vault
 
 [Project Access Token API]: https://docs.gitlab.com/ee/api/resource_access_tokens.html
+[Group Access Token API]: https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html

--- a/plugin/const.go
+++ b/plugin/const.go
@@ -18,6 +18,8 @@ import "github.com/xanzy/go-gitlab"
 
 type PAT = gitlab.ProjectAccessToken
 
+type GAT = gitlab.GroupAccessToken
+
 const (
 	pathPatternConfig = "config"
 	pathPatternToken  = "token"

--- a/plugin/gitlab_client_test.go
+++ b/plugin/gitlab_client_test.go
@@ -87,3 +87,7 @@ func (ac *mockGitlabClient) CreateProjectAccessToken(tokenStorage *BaseTokenStor
 // func (ac *mockGitlabClient) RevokeProjectAccessToken(tokenStorage *BaseTokenStorageEntry) error {
 // 	return nil
 // }
+
+func (ac *mockGitlabClient) CreateGroupAccessToken(tokenStorage *BaseTokenStorageEntry, expiresAt *time.Time) (*GAT, error) {
+	return nil, nil
+}

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -159,7 +159,7 @@ Configure the Gitlab backend.
 `
 
 const pathConfigHelpDesc = `
-The Gitlab backend requires credentials for creating a project access token.
+The Gitlab backend requires credentials for creating an access token.
 This endpoint is used to configure those credentials as well as default values
 for the backend in general.
 `

--- a/plugin/path_role_test.go
+++ b/plugin/path_role_test.go
@@ -40,6 +40,7 @@ func TestPathRole(t *testing.T) {
 		"name":         "role-test",
 		"scopes":       []string{"api", "read_repository"},
 		"access_level": 30,
+		"token_type":   "project",
 	}
 	t.Run("successful", func(t *testing.T) {
 		roleName := "successful"
@@ -92,6 +93,7 @@ func TestPathRole(t *testing.T) {
 			"id":           -1,
 			"token_ttl":    fmt.Sprintf("%dh", 30*24),
 			"access_level": 31,
+			"token_type":   "foo",
 		}
 		resp, err := testRoleCreate(t, backend, storage, roleName, d)
 		require.NoError(t, err)
@@ -102,6 +104,7 @@ func TestPathRole(t *testing.T) {
 		require.Contains(t, resp.Data["error"], "scopes are empty")
 		require.Contains(t, resp.Data["error"], "exceeds configured maximum ttl")
 		require.Contains(t, resp.Data["error"], "invalid access level")
+		require.Contains(t, resp.Data["error"], "token_type must be either")
 	})
 }
 
@@ -116,9 +119,10 @@ func TestPathRoleList(t *testing.T) {
 	}
 	testConfigUpdate(t, backend, storage, conf)
 	data := map[string]interface{}{
-		"id":     1,
-		"name":   "role-test",
-		"scopes": []string{"api", "read_repository"},
+		"id":         1,
+		"name":       "role-test",
+		"scopes":     []string{"api", "read_repository"},
+		"token_type": "project",
 	}
 
 	var listResp map[string]interface{}

--- a/plugin/path_token.go
+++ b/plugin/path_token.go
@@ -27,11 +27,11 @@ import (
 var accessTokenSchema = map[string]*framework.FieldSchema{
 	"id": {
 		Type:        framework.TypeInt,
-		Description: "Project ID to create a project access token for",
+		Description: "Project/Group ID to create an access token for",
 	},
 	"name": {
 		Type:        framework.TypeString,
-		Description: "The name of the project access token",
+		Description: "The name of the access token",
 	},
 	"scopes": {
 		Type:        framework.TypeCommaStringSlice,
@@ -43,7 +43,11 @@ var accessTokenSchema = map[string]*framework.FieldSchema{
 	},
 	"access_level": {
 		Type:        framework.TypeInt,
-		Description: "access level of project access token",
+		Description: "access level of access token",
+	},
+	"token_type": {
+		Type:        framework.TypeString,
+		Description: "access token type",
 	},
 }
 
@@ -72,10 +76,10 @@ func (b *GitlabBackend) pathTokenCreate(ctx context.Context, req *logical.Reques
 
 	config, err := getConfig(ctx, req.Storage)
 	if err != nil {
-		return logical.ErrorResponse("failed to obtain artifactory config - %s", err.Error()), nil
+		return logical.ErrorResponse("failed to obtain gitlab config - %s", err.Error()), nil
 	}
 	if config == nil {
-		return logical.ErrorResponse("artifactory backend configuration has not been set up"), nil
+		return logical.ErrorResponse("gitlab backend configuration has not been set up"), nil
 	}
 	err = tokenStorage.assertValid(config.MaxTTL)
 	if err != nil {
@@ -101,7 +105,7 @@ func pathToken(b *GitlabBackend) []*framework.Path {
 				logical.CreateOperation: &framework.PathOperation{
 
 					Callback: b.pathTokenCreate,
-					Summary:  "Create a project access token",
+					Summary:  "Create an access token",
 					Examples: tokenExamples,
 				},
 				logical.UpdateOperation: &framework.PathOperation{
@@ -116,18 +120,18 @@ func pathToken(b *GitlabBackend) []*framework.Path {
 	return paths
 }
 
-const pathTokenHelpSyn = `Generate a project access token for a given project with token name, scopes.`
+const pathTokenHelpSyn = `Generate an access token for a given project/group with token name, scopes.`
 const pathTokenHelpDesc = `
-This path allows you to generate a project access token. You must supply a project id to generate a token for, a name, which 
+This path allows you to generate an access token. You must supply a project/group id to generate a token for, a name, which 
 will be used as a name field in Gitlab, and scopes for the generated project access token.
 `
 
 var tokenExamples = []framework.RequestExample{
 	{
-		Description: "Create a project access token",
+		Description: "Create an access token",
 		Data: map[string]interface{}{
 			"id":     1,
-			"name":   "MyProjectAccessToken",
+			"name":   "MyAccessToken",
 			"scopes": []string{"read_api", "read_repository"},
 		},
 	},

--- a/plugin/path_token_role.go
+++ b/plugin/path_token_role.go
@@ -63,7 +63,7 @@ func pathRoleToken(b *GitlabBackend) []*framework.Path {
 				logical.CreateOperation: &framework.PathOperation{
 
 					Callback: b.pathRoleTokenCreate,
-					Summary:  "Create a project access token based on a predefined role",
+					Summary:  "Create an access token based on a predefined role",
 					Examples: roleTokenExamples,
 				},
 				logical.UpdateOperation: &framework.PathOperation{
@@ -78,15 +78,15 @@ func pathRoleToken(b *GitlabBackend) []*framework.Path {
 	return paths
 }
 
-const pathRoleTokenHelpSyn = `Generate a project access token for a given project based on a predefined role`
+const pathRoleTokenHelpSyn = `Generate an access token for a given project/group based on a predefined role`
 const pathRoleTokenHelpDesc = `
-This path allows you to generate a project access token based on a predefined role. You must create a role beforehand in /roles/ path,
-whose parameters are used to generate a project access token.
+This path allows you to generate an access token based on a predefined role. You must create a role beforehand in /roles/ path,
+whose parameters are used to generate an access token.
 `
 
 var roleTokenExamples = []framework.RequestExample{
 	{
-		Description: "Create a project access token based on a predefined role",
+		Description: "Create an access token based on a predefined role",
 		Data: map[string]interface{}{
 			"role_name": "MyRole",
 		},

--- a/plugin/path_token_role_test.go
+++ b/plugin/path_token_role_test.go
@@ -36,9 +36,10 @@ func TestAccRoleToken(t *testing.T) {
 
 	t.Run("successfully create", func(t *testing.T) {
 		data := map[string]interface{}{
-			"id":     ID,
-			"name":   "vault-role-test",
-			"scopes": []string{"read_api"},
+			"id":         ID,
+			"name":       "vault-role-test",
+			"scopes":     []string{"read_api"},
+			"token_type": "project",
 		}
 		roleName := "successful"
 		mustRoleCreate(t, backend, req.Storage, roleName, data)
@@ -61,6 +62,7 @@ func TestAccRoleToken(t *testing.T) {
 			"name":         "vault-role-test-access-level",
 			"access_level": 30,
 			"scopes":       []string{"read_api"},
+			"token_type":   "project",
 		}
 		roleName := "successful-access-level"
 		mustRoleCreate(t, backend, req.Storage, roleName, data)

--- a/plugin/path_token_test.go
+++ b/plugin/path_token_test.go
@@ -36,9 +36,10 @@ func TestAccToken(t *testing.T) {
 
 	t.Run("successfully create", func(t *testing.T) {
 		d := map[string]interface{}{
-			"id":     ID,
-			"name":   "vault-test",
-			"scopes": []string{"read_api"},
+			"id":         ID,
+			"name":       "vault-test",
+			"scopes":     []string{"read_api"},
+			"token_type": "project",
 		}
 		resp, err := testIssueToken(t, backend, req, d)
 		require.NoError(t, err)
@@ -57,6 +58,7 @@ func TestAccToken(t *testing.T) {
 			"name":       "vault-test-expires",
 			"scopes":     []string{"read_api"},
 			"expires_at": e.Unix(),
+			"token_type": "project",
 		}
 		resp, err := testIssueToken(t, backend, req, d)
 		require.NoError(t, err)
@@ -75,6 +77,7 @@ func TestAccToken(t *testing.T) {
 			"scopes":       []string{"read_api"},
 			"access_level": 30,
 			"expires_at":   e.Unix(),
+			"token_type":   "project",
 		}
 		resp, err := testIssueToken(t, backend, req, d)
 		require.NoError(t, err)
@@ -101,6 +104,7 @@ func TestAccToken(t *testing.T) {
 		require.Contains(t, resp.Data["error"], "id is empty or invalid")
 		require.Contains(t, resp.Data["error"], "name is empty")
 		require.Contains(t, resp.Data["error"], "scopes are empty")
+		require.Contains(t, resp.Data["error"], "token_type must be either")
 	})
 
 	t.Run("exceeding max token lifetime", func(t *testing.T) {
@@ -118,6 +122,7 @@ func TestAccToken(t *testing.T) {
 			"name":       "vault-test-exceeding-lifetime",
 			"scopes":     []string{"read_api"},
 			"expires_at": e.Unix(),
+			"token_type": "project",
 		}
 		resp, err := testIssueToken(t, backend, req, d)
 		require.NoError(t, err)

--- a/plugin/token.go
+++ b/plugin/token.go
@@ -25,6 +25,11 @@ import (
 
 var errInvalidAccessLevel = errors.New("invalid access level")
 
+const (
+	tokenTypeProject string = "project"
+	tokenTypeGroup   string = "group"
+)
+
 type TokenStorageEntry struct {
 	BaseTokenStorage BaseTokenStorageEntry
 	ExpiresAt        *time.Time `json:"expires_at" structs:"expires_at" mapstructure:"expires_at,omitempty"`
@@ -36,6 +41,7 @@ type BaseTokenStorageEntry struct {
 	Name        string   `json:"name" structs:"name" mapstructure:"name"`
 	Scopes      []string `json:"scopes" structs:"scopes" mapstructure:"scopes"`
 	AccessLevel int      `json:"access_level" structs:"access_level" mapstructure:"access_level,omitempty"`
+	TokenType   string   `json:"token_type" struct:"token_type" mapstructure:"token_type,omitempty"`
 }
 
 func (tokenStorage *TokenStorageEntry) assertValid(maxTTL time.Duration) error {
@@ -77,7 +83,21 @@ func (baseTokenStorage *BaseTokenStorageEntry) assertValid() error {
 		err = multierror.Append(err, errInvalidAccessLevel)
 	}
 
+	// no default type for access token
+	if e := validateTokenType(baseTokenStorage.TokenType); err != nil {
+		err = multierror.Append(err, e)
+	}
+
 	return err.ErrorOrNil()
+}
+
+func validateTokenType(t string) error {
+	switch t {
+	case tokenTypeGroup, tokenTypeProject:
+		return nil
+	default:
+		return fmt.Errorf("token_type must be either %s or %s", tokenTypeProject, tokenTypeGroup)
+	}
 }
 
 func (tokenStorage *TokenStorageEntry) retrieve(data *framework.FieldData) {
@@ -100,5 +120,8 @@ func (baseTokenStorage *BaseTokenStorageEntry) retrieve(data *framework.FieldDat
 	}
 	if accessLevelRaw, ok := data.GetOk("access_level"); ok {
 		baseTokenStorage.AccessLevel = accessLevelRaw.(int)
+	}
+	if tokenType, ok := data.GetOk("token_type"); ok {
+		baseTokenStorage.TokenType = tokenType.(string)
 	}
 }


### PR DESCRIPTION
as described in the issue, only adding `token_type` in BaseTokenStorage and it'll do population. 

TODO:  switch to create group/project access token based on `token_type` field

haven't tested with gitlab instance nor vault instance yet

close #36 

